### PR TITLE
docker,etc: add version control

### DIFF
--- a/docker/bridge/Dockerfile
+++ b/docker/bridge/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.21
 SHELL ["/bin/ash", "-c"]
+ARG TAG=9ba97f1735022fb5f811d9c2a304dda33fae1ad1
 
 # ethtool 6.11 is failing in '-X hkey' command on Linux kernel 6.1
 RUN <<EOF
@@ -8,5 +9,5 @@ RUN <<EOF
   apk add --no-cache arping docker-cli 'ethtool<6.11' iproute2 jq util-linux-misc
 EOF
 
-ADD --chmod=755 https://github.com/jpetazzo/pipework/raw/9ba97f1735022fb5f811d9c2a304dda33fae1ad1/pipework /usr/local/bin/
+ADD --chmod=755 https://github.com/jpetazzo/pipework/raw/${TAG}/pipework /usr/local/bin/
 COPY --chmod=755 *.sh /usr/local/bin/

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,6 +4,13 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/..
 D=$1
 shift
 
+TAG=${1:-}
+TAG_ARG=()
+if [[ -n "${TAG:-}" ]]; then
+  shift
+  TAG_ARG=(--build-arg TAG="$TAG")
+fi
+
 PULL=--pull
 if [[ ${NOPULL:-} -eq 1 ]]; then
   PULL=''
@@ -16,30 +23,35 @@ build_image() {
   if grep -q localhost/ docker/$NAME/Dockerfile; then
     PULL1=''
   fi
-  docker build $PULL1 --progress=plain -t 5gdeploy.localhost/$NAME "$@" docker/$NAME
+  docker build $PULL1 --progress=plain -t 5gdeploy.localhost/$NAME "$@" docker/$NAME "${TAG_ARG[@]}"
 }
 
 build_oai_nwdaf_microservice() {
   local MS=$1
-  shift
+  local TAG=$2
+  shift 2
   docker build $PULL --progress=plain -t 5gdeploy.localhost/oai-nwdaf-$MS \
     "$@" -f docker/Dockerfile.$MS \
-    https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf.git#$BRANCH:components/oai-nwdaf-$MS
+    https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf.git#$TAG:components/oai-nwdaf-$MS
 }
 
 build_oai_nwdaf() {
-  local BRANCH=http2_server_support
+  if [[ -n "${TAG:-}" ]]; then
+    TAG=http2_server_support
+    TAG_ARG=(--build-arg TAG="$TAG")
+  fi
 
   for MS in engine nbi-analytics nbi-events nbi-ml sbi; do
-    build_oai_nwdaf_microservice $MS \
+    build_oai_nwdaf_microservice $MS "$TAG" \
       --build-arg BUILD_IMAGE=golang:1.23-alpine3.21 \
-      --build-arg TARGET_IMAGE=alpine:3.21
+      --build-arg TARGET_IMAGE=alpine:3.21 \
+      "${TAG_ARG[@]}"
   done
 
-  build_oai_nwdaf_microservice engine-ads
+  build_oai_nwdaf_microservice engine-ads "$TAG"
 
   docker build $PULL --progress=plain -t 5gdeploy.localhost/oai-nwdaf-cli \
-    --build-arg branch=$BRANCH \
+    "${TAG_ARG[@]}" \
     docker/oai-nwdaf-cli
 }
 
@@ -61,9 +73,21 @@ build_phoenix() {
   build_image phoenix
 }
 
+ubuntu_codename() {
+  UBUNTU_CODENAME=$(grep -oP '^UBUNTU_CODENAME=\K.*' /etc/os-release 2>/dev/null)
+  if [[ -z "$UBUNTU_CODENAME" ]]; then
+    UBUNTU_CODENAME=$(grep -oP '^VERSION_CODENAME=\K.*' /etc/os-release 2>/dev/null)
+  fi
+  if [[ -z "$UBUNTU_CODENAME" ]]; then
+    echo "Unable to determine Ubuntu codename from /etc/os-release" >&2
+    exit 1
+  fi
+  echo "$UBUNTU_CODENAME"
+}
+
 case $D in
   gtp5g)
-    build_image gtp5g --build-arg BUILDPACK_TAG="$(lsb_release -c -s)"
+    build_image gtp5g --build-arg BUILDPACK_TAG="$(ubuntu_codename)"
     ;;
   oai-nwdaf)
     build_oai_nwdaf

--- a/docker/eupf/Dockerfile
+++ b/docker/eupf/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/edgecomllc/eupf:main
-FROM $BASE
+ARG TAG=54ed069c6cdf1da18b09bd78cb166bc4e4dd1ceb # v0.7.0
+FROM ghcr.io/edgecomllc/eupf:${TAG}
 SHELL ["/bin/ash", "-c"]
 RUN apk add --no-cache ethtool iproute2

--- a/docker/gnbsim/Dockerfile
+++ b/docker/gnbsim/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.24-alpine3.21 AS build
 SHELL ["/bin/ash", "-c"]
-ADD https://github.com/omec-project/gnbsim/archive/d3fce7e35a69b9f5d670242a93b7d1bee8842ecf.zip /gnbsim.zip
+ARG TAG=d3fce7e35a69b9f5d670242a93b7d1bee8842ecf
+ADD https://github.com/omec-project/gnbsim/archive/${TAG}.zip /gnbsim.zip
 
 RUN --mount=type=cache,id=go1.24-build,target=/root/.cache/go-build,sharing=locked \
 <<EOF

--- a/docker/gtp5g/Dockerfile
+++ b/docker/gtp5g/Dockerfile
@@ -1,6 +1,7 @@
 ARG BUILDPACK_TAG=noble
 FROM buildpack-deps:$BUILDPACK_TAG
 SHELL ["/bin/bash", "-c"]
+ARG TAG=v0.9.13
 
 RUN --mount=type=cache,id=gtp5g-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=gtp5g-apt-cache,target=/var/lib/apt,sharing=locked \
@@ -12,6 +13,6 @@ RUN --mount=type=cache,id=gtp5g-apt-cache,target=/var/cache/apt,sharing=locked \
   apt-get install -y --no-install-recommends kmod
 EOF
 
-ADD https://github.com/free5gc/gtp5g/archive/v0.9.13.zip /gtp5g.zip
+ADD https://github.com/free5gc/gtp5g/archive/${TAG}.zip /gtp5g.zip
 COPY --chmod=755 gtp5g-load.sh /
 ENTRYPOINT ["/gtp5g-load.sh"]

--- a/docker/oai-nwdaf-cli/Dockerfile
+++ b/docker/oai-nwdaf-cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine3.21
 SHELL ["/bin/ash", "-c"]
-ARG branch=master
-ADD https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf/-/archive/$branch/oai-cn5g-nwdaf-$branch.zip?path=cli /nwdaf.zip
+ARG TAG=http2_server_support
+ADD https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf/-/archive/$TAG/oai-cn5g-nwdaf-$TAG.zip?path=cli /nwdaf.zip
 
 RUN <<EOF
   set -euxo pipefail

--- a/docker/open5gs/Dockerfile
+++ b/docker/open5gs/Dockerfile
@@ -1,6 +1,7 @@
+ARG TAG=2.7.2
 FROM crazymax/yasu AS yasu
 
-FROM gradiant/open5gs:2.7.2
+FROM gradiant/open5gs:${TAG}
 SHELL ["/bin/bash", "-c"]
 USER root:root
 COPY --from=yasu /usr/local/bin/yasu /usr/local/bin/yasu

--- a/docker/packetrusher/Dockerfile
+++ b/docker/packetrusher/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.24-alpine3.21 AS build
 SHELL ["/bin/ash", "-c"]
-ADD https://github.com/HewlettPackard/PacketRusher/archive/80a7f4bc63d9563a8ec58ba126440d94018a35a2.zip /PacketRusher.zip
+ARG TAG=80a7f4bc63d9563a8ec58ba126440d94018a35a2
+ADD https://github.com/HewlettPackard/PacketRusher/archive/${TAG}.zip /PacketRusher.zip
 
 RUN --mount=type=cache,id=go1.24-build,target=/root/.cache/go-build,sharing=locked \
 <<EOF

--- a/docker/sockperf/Dockerfile
+++ b/docker/sockperf/Dockerfile
@@ -1,6 +1,7 @@
 FROM buildpack-deps:bookworm AS build
 SHELL ["/bin/bash", "-c"]
-ADD https://github.com/Mellanox/sockperf/archive/19accb5229503dac7833f03713b978cb7fc48762.zip /sockperf.zip
+ARG TAG=19accb5229503dac7833f03713b978cb7fc48762
+ADD https://github.com/Mellanox/sockperf/archive/${TAG}.zip /sockperf.zip
 
 RUN <<EOF
   set -euxo pipefail

--- a/docker/srsran5g/Dockerfile
+++ b/docker/srsran5g/Dockerfile
@@ -1,4 +1,5 @@
-FROM gradiant/srsran-5g:24_10_1
+ARG TAG=24_10_1
+FROM gradiant/srsran-5g:${TAG}
 SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=cache,id=jammy-apt-cache,target=/var/cache/apt,sharing=locked \

--- a/docker/ueransim/Dockerfile
+++ b/docker/ueransim/Dockerfile
@@ -1,5 +1,6 @@
 FROM free5gc/ueransim
 SHELL ["/bin/bash", "-c"]
+ARG TAG=2fc85e3e422b9a981d330bf6ff945136bfae97f3
 
 RUN --mount=type=cache,id=bullseye-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=bullseye-apt-cache,target=/var/lib/apt,sharing=locked \
@@ -12,5 +13,5 @@ RUN --mount=type=cache,id=bullseye-apt-cache,target=/var/cache/apt,sharing=locke
 EOF
 
 ADD --chmod=755 https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 /usr/local/bin/yq
-ADD --chmod=644 https://github.com/aligungr/UERANSIM/raw/2fc85e3e422b9a981d330bf6ff945136bfae97f3/config/custom-gnb.yaml /ueransim/config/
-ADD --chmod=644 https://github.com/aligungr/UERANSIM/raw/2fc85e3e422b9a981d330bf6ff945136bfae97f3/config/custom-ue.yaml /ueransim/config/
+ADD --chmod=644 https://github.com/aligungr/UERANSIM/raw/${TAG}/config/custom-gnb.yaml /ueransim/config/
+ADD --chmod=644 https://github.com/aligungr/UERANSIM/raw/${TAG}/config/custom-ue.yaml /ueransim/config/

--- a/docker/virt/Dockerfile
+++ b/docker/virt/Dockerfile
@@ -1,8 +1,8 @@
 FROM 5gdeploy.localhost/gtp5g AS gtp5g
 FROM crazymax/yasu AS yasu
-
 FROM debian:bookworm
 SHELL ["/bin/bash", "-c"]
+ARG TAG=v24.11
 
 RUN --mount=type=cache,id=bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=bookworm-apt-cache,target=/var/lib/apt,sharing=locked \
@@ -22,6 +22,6 @@ EOF
 
 COPY --from=yasu /usr/local/bin/yasu /usr/local/bin/yasu
 ADD --chmod=755 https://github.com/0xef53/qmp-shell/releases/download/v2.0.1/qmp-shell /usr/local/bin/
-ADD --chmod=755 https://github.com/DPDK/dpdk/raw/refs/tags/v24.11/usertools/dpdk-devbind.py /usr/local/bin/dpdk-devbind.py
+ADD --chmod=755 https://github.com/DPDK/dpdk/raw/${TAG}/usertools/dpdk-devbind.py /usr/local/bin/dpdk-devbind.py
 COPY --from=gtp5g --chmod=644 /gtp5g.zip /
 COPY --from=gtp5g --chmod=755 /gtp5g-load.sh /

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-5gdeploy supports Ubuntu 24.04 operating system only.
+5gdeploy supports Linux distributions based on Ubuntu 20.04, 22.04, and 24.04.
 
 ## Dependencies
 
@@ -67,6 +67,23 @@ cd ~/5gdeploy
 ./docker/build.sh ueransim
 # change 'ueransim' to the image that you want to rebuild
 ```
+
+### Installation Options
+The following optional arguments can be passed to `./install.sh`:
+* `--bridge-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for bridge (_default: [9ba97f1735022fb5f811d9c2a304dda33fae1ad1](https://github.com/jpetazzo/pipework)_)
+* `--eupf-version <version>`: Specify a **branch** or **commit hash** to use for EUPF (_default: [main](https://github.com/edgecomllc/eupf)_)
+* `--free5gc-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for free5GC (_default: [master](https://github.com/free5gc/free5gc-compose)_)
+* `--free5gc-webclient-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for free5GC webconsole (_default: [f4932d569dd0045fc31baca062a05d7b34e3e8e0](https://github.com/free5gc/webconsole)_)
+* `--gnbsim-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for gnbsim (_default: [d3fce7e35a69b9f5d670242a93b7d1bee8842ecf](https://github.com/omec-project/gnbsim)_)
+* `--gtp5g-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for gtp5g (_default: [v0.9.13](https://github.com/free5gc/gtp5g)_)
+* `--oai-fed-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for OAI (_default: [master](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed)_)
+* `--oai-nwdaf-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for OAI-NWDAF (_default: [http2_server_support](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf)_)
+* `--open5gs-version <version>`: Specify a **release** to use for Open5GS (_default: [2.7.2](https://hub.docker.com/r/gradiant/open5gs)_)
+* `--packetrusher-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for Packetrusher (_default: [80a7f4bc63d9563a8ec58ba126440d94018a35a2](https://github.com/packetrusher/packetrusher)_)
+* `--sockperf-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for Sockperf (_default: [19accb5229503dac7833f03713b978cb7fc48762](https://github.com/Mellanox/sockperf)_)
+* `--srsran5g-version <version>`: Specify a **release** to use for srsRAN 5G (_default: [24_10_1](https://hub.docker.com/r/gradiant/srsran-5g)_)
+* `--ueransim-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for UERANSIM (_default: [2fc85e3e422b9a981d330bf6ff945136bfae97f3](https://github.com/aligungr/UERANSIM)_)
+* `--virt-dpdk-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for DPDK (_default: [v24.11](https://github.com/DPDK/dpdk)_)
 
 ## Secondary Host
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,20 +70,20 @@ cd ~/5gdeploy
 
 ### Installation Options
 The following optional arguments can be passed to `./install.sh`:
-* `--bridge-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for bridge (_default: [9ba97f1735022fb5f811d9c2a304dda33fae1ad1](https://github.com/jpetazzo/pipework)_)
-* `--eupf-version <version>`: Specify a **branch** or **commit hash** to use for EUPF (_default: [main](https://github.com/edgecomllc/eupf)_)
+* `--pipework-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for Pipework (_default: [9ba97f1735022fb5f811d9c2a304dda33fae1ad1](https://github.com/jpetazzo/pipework)_)
+* `--eupf-version <version>`: Specify a **branch** or **commit hash** to use for eUPF (_default: [main](https://github.com/edgecomllc/eupf)_)
 * `--free5gc-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for free5GC (_default: [master](https://github.com/free5gc/free5gc-compose)_)
-* `--free5gc-webclient-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for free5GC webconsole (_default: [f4932d569dd0045fc31baca062a05d7b34e3e8e0](https://github.com/free5gc/webconsole)_)
-* `--gnbsim-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for gnbsim (_default: [d3fce7e35a69b9f5d670242a93b7d1bee8842ecf](https://github.com/omec-project/gnbsim)_)
+* `--free5gc-webconsole-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for free5GC Web Console (_default: [f4932d569dd0045fc31baca062a05d7b34e3e8e0](https://github.com/free5gc/webconsole)_)
+* `--gnbsim-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for gNBSim (_default: [d3fce7e35a69b9f5d670242a93b7d1bee8842ecf](https://github.com/omec-project/gnbsim)_)
 * `--gtp5g-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for gtp5g (_default: [v0.9.13](https://github.com/free5gc/gtp5g)_)
-* `--oai-fed-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for OAI (_default: [master](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed)_)
-* `--oai-nwdaf-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for OAI-NWDAF (_default: [http2_server_support](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf)_)
+* `--oai-fed-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for OAI-CN5G (_default: [master](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed)_)
+* `--oai-nwdaf-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for OAI-CN5G-NWDAF (_default: [http2_server_support](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-nwdaf)_)
 * `--open5gs-version <version>`: Specify a **release** to use for Open5GS (_default: [2.7.2](https://hub.docker.com/r/gradiant/open5gs)_)
-* `--packetrusher-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for Packetrusher (_default: [80a7f4bc63d9563a8ec58ba126440d94018a35a2](https://github.com/packetrusher/packetrusher)_)
-* `--sockperf-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for Sockperf (_default: [19accb5229503dac7833f03713b978cb7fc48762](https://github.com/Mellanox/sockperf)_)
-* `--srsran5g-version <version>`: Specify a **release** to use for srsRAN 5G (_default: [24_10_1](https://hub.docker.com/r/gradiant/srsran-5g)_)
+* `--packetrusher-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for PacketRusher (_default: [80a7f4bc63d9563a8ec58ba126440d94018a35a2](https://github.com/HewlettPackard/PacketRusher)_)
+* `--sockperf-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for sockperf (_default: [19accb5229503dac7833f03713b978cb7fc48762](https://github.com/Mellanox/sockperf)_)
+* `--srsran5g-version <version>`: Specify a **release** to use for srsRAN Project (_default: [24_10_1](https://hub.docker.com/r/gradiant/srsran-5g)_)
 * `--ueransim-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for UERANSIM (_default: [2fc85e3e422b9a981d330bf6ff945136bfae97f3](https://github.com/aligungr/UERANSIM)_)
-* `--virt-dpdk-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for DPDK (_default: [v24.11](https://github.com/DPDK/dpdk)_)
+* `--dpdk-version <version>`: Specify a **branch**, **tag**, or **commit hash** to use for DPDK (_default: [v24.11](https://github.com/DPDK/dpdk)_)
 
 ## Secondary Host
 

--- a/eupf/download.sh
+++ b/eupf/download.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
+TAG=${1:-v0.7.0}
 
 mkdir -p grafana
-curl -sfLS https://github.com/edgecomllc/eupf/archive/refs/tags/v0.7.0.tar.gz |
+curl -sfLS "https://github.com/edgecomllc/eupf/archive/${TAG}.tar.gz" |
   tar -C grafana -xzv --strip-components=3 --wildcards 'eupf-*/.deploy/grafana'

--- a/free5gc/download.sh
+++ b/free5gc/download.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
-TAG=${1:-master}
+TAG=${1:-}
+TAG=${TAG:-master}
+TAG_WEBCONSOLE=${2:-f4932d569dd0045fc31baca062a05d7b34e3e8e0}
 
 if [[ -d free5gc-compose ]]; then
   git -C free5gc-compose fetch
@@ -11,7 +13,7 @@ else
   git clone --branch "${TAG}" https://github.com/free5gc/free5gc-compose.git
 fi
 
-curl -o webconsole.yaml -fsLS https://github.com/free5gc/webconsole/raw/f4932d569dd0045fc31baca062a05d7b34e3e8e0/frontend/webconsole.yaml
+curl -o webconsole.yaml -fsLS "https://github.com/free5gc/webconsole/raw/${TAG_WEBCONSOLE}/frontend/webconsole.yaml"
 docker run --rm --network none -v ./webconsole-openapi:/output -v ./webconsole.yaml:/webconsole.yaml:ro \
   openapitools/openapi-generator-cli generate -i /webconsole.yaml -g typescript-fetch -o /output
 docker run --rm -v ./webconsole-openapi:/output alpine:3.21 chown -R $(id -u):$(id -g) /output

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,101 @@ for CMD in corepack docker jq yq; do
   fi
 done
 
+# Parse command line arguments for optional version tags
+declare -A TAGS=(
+  [bridge]=""
+  [eupf]=""
+  [free5gc]=""
+  [free5gc-webclient]=""
+  [gnbsim]=""
+  [gtp5g]=""
+  [oai-fed]=""
+  [oai-nwdaf]=""
+  [open5gs]=""
+  [packetrusher]=""
+  [srsran5g]=""
+  [ueransim]=""
+)
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-version)
+      TAGS[bridge]="$2"
+      msg "Argument bridge-version = ${TAGS[bridge]}"
+      shift 2
+      ;;
+    --eupf-version)
+      TAGS[eupf]="$2"
+      msg "Argument eupf-version = ${TAGS[eupf]}"
+      shift 2
+      ;;
+    --free5gc-version)
+      TAGS[free5gc]="$2"
+      msg "Argument free5gc-version = ${TAGS[free5gc]}"
+      shift 2
+      ;;
+    --free5gc-webclient-version)
+      TAGS[free5gc-webclient]="$2"
+      msg "Argument free5gc-webclient-version = ${TAGS[free5gc-webclient]}"
+      shift 2
+      ;;
+    --gnbsim-version)
+      TAGS[gnbsim]="$2"
+      msg "Argument gnbsim-version = ${TAGS[gnbsim]}"
+      shift 2
+      ;;
+    --gtp5g-version)
+      TAGS[gtp5g]="$2"
+      msg "Argument gtp5g-version = ${TAGS[gtp5g]}"
+      shift 2
+      ;;
+    --oai-fed-version)
+      TAGS[oai-fed]="$2"
+      msg "Argument oai-fed-version = ${TAGS[oai-fed]}"
+      shift 2
+      ;;
+    --oai-nwdaf-version)
+      TAGS[oai-nwdaf]="$2"
+      msg "Argument oai-nwdaf-version = ${TAGS[oai-nwdaf]}"
+      shift 2
+      ;;
+    --open5gs-version)
+      TAGS[open5gs]="$2"
+      msg "Argument open5gs-version = ${TAGS[open5gs]}"
+      shift 2
+      ;;
+    --packetrusher-version)
+      TAGS[packetrusher]="$2"
+      msg "Argument packetrusher-version = ${TAGS[packetrusher]}"
+      shift 2
+      ;;
+    --sockperf-version)
+      TAGS[sockperf]="$2"
+      msg "Argument sockperf-version = ${TAGS[sockperf]}"
+      shift 2
+      ;;
+    --srsran5g-version)
+      TAGS[srsran5g]="$2"
+      msg "Argument srsran5g-version = ${TAGS[srsran5g]}"
+      shift 2
+      ;;
+    --ueransim-version)
+      TAGS[ueransim]="$2"
+      msg "Argument ueransim-version = ${TAGS[ueransim]}"
+      shift 2
+      ;;
+    --virt-dpdk-version)
+      TAGS[virt]="$2"
+      msg "Argument virt-dpdk-version = ${TAGS[virt]}"
+      shift 2
+      ;;
+    *)
+      die "Unknown argument: \"$1\""
+      shift
+      ;;
+  esac
+done
+
 if ! docker version &>/dev/null; then
   die Unable to access Docker, check docker group membership
 fi
@@ -26,14 +121,19 @@ fi
 msg Installing 5gdeploy
 corepack pnpm install
 bash ./types/build-schema.sh
-bash ./eupf/download.sh
-bash ./free5gc/download.sh
-bash ./oai/download.sh
-bash ./open5gs/download.sh
+bash ./eupf/download.sh "${TAGS[eupf]}"
+bash ./free5gc/download.sh "${TAGS[free5gc]}" "${TAGS[free5gc-webclient]}"
+bash ./oai/download.sh "${TAGS[oai-fed]}" "${TAGS[oai-nwdaf]}"
+bash ./open5gs/download.sh "${TAGS[open5gs]}"
 
 for IMG in bridge dn eupf free5gc-webclient gnbsim gtp5g iperf2 ns3http open5gs packetrusher sockperf srsran5g ueransim virt; do
-  msg Building Docker image $IMG
-  ./docker/build.sh $IMG
+  TAG=${TAGS[$IMG]:-}
+  if [[ -z "$TAG" ]]; then
+    msg "Building Docker image $IMG"
+  else
+    msg "Building Docker image $IMG with version $TAG"
+  fi
+  ./docker/build.sh $IMG $TAG
 done
 
 msg 5gdeploy is installed

--- a/install.sh
+++ b/install.sh
@@ -37,9 +37,9 @@ declare -A TAGS=(
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --bridge-version)
+    --pipework-version)
       TAGS[bridge]="$2"
-      msg "Argument bridge-version = ${TAGS[bridge]}"
+      msg "Argument pipework-version = ${TAGS[bridge]}"
       shift 2
       ;;
     --eupf-version)
@@ -52,9 +52,9 @@ while [[ $# -gt 0 ]]; do
       msg "Argument free5gc-version = ${TAGS[free5gc]}"
       shift 2
       ;;
-    --free5gc-webclient-version)
+    --free5gc-webconsole-version)
       TAGS[free5gc-webclient]="$2"
-      msg "Argument free5gc-webclient-version = ${TAGS[free5gc-webclient]}"
+      msg "Argument free5gc-webconsole-version = ${TAGS[free5gc-webclient]}"
       shift 2
       ;;
     --gnbsim-version)
@@ -102,9 +102,9 @@ while [[ $# -gt 0 ]]; do
       msg "Argument ueransim-version = ${TAGS[ueransim]}"
       shift 2
       ;;
-    --virt-dpdk-version)
+    --dpdk-version)
       TAGS[virt]="$2"
-      msg "Argument virt-dpdk-version = ${TAGS[virt]}"
+      msg "Argument dpdk-version = ${TAGS[virt]}"
       shift 2
       ;;
     *)
@@ -128,11 +128,7 @@ bash ./open5gs/download.sh "${TAGS[open5gs]}"
 
 for IMG in bridge dn eupf free5gc-webclient gnbsim gtp5g iperf2 ns3http open5gs packetrusher sockperf srsran5g ueransim virt; do
   TAG=${TAGS[$IMG]:-}
-  if [[ -z "$TAG" ]]; then
-    msg "Building Docker image $IMG"
-  else
-    msg "Building Docker image $IMG with version $TAG"
-  fi
+  msg "Building Docker image $IMG"
   ./docker/build.sh $IMG $TAG
 done
 

--- a/oai/download.sh
+++ b/oai/download.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
-FED_TAG=${1:-master}
+FED_TAG=${1:-}
+FED_TAG=${FED_TAG:-master}
 NWDAF_TAG=${2:-master}
 
 mkdir -p fed

--- a/open5gs/download.sh
+++ b/open5gs/download.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
+TAG=${1:-2.7.2}
 
-curl -sfLS "https://github.com/open5gs/open5gs/raw/v2.7.2/misc/db/open5gs-dbctl" -o open5gs-dbctl
+curl -sfLS "https://github.com/open5gs/open5gs/raw/v${TAG}/misc/db/open5gs-dbctl" -o open5gs-dbctl


### PR DESCRIPTION
This commit adds optional version control to 5gdeploy by including arguments to specify the version for each docker image/git repository. The default functionality remains the same, however, `./install.sh` is now equivalent to the following:

```
./install.sh \
  --bridge-version 9ba97f1735022fb5f811d9c2a304dda33fae1ad1 \
  --eupf-version main \
  --free5gc-version master \
  --free5gc-webclient-version f4932d569dd0045fc31baca062a05d7b34e3e8e0 \
  --gnbsim-version d3fce7e35a69b9f5d670242a93b7d1bee8842ecf \
  --gtp5g-version v0.9.13 \
  --oai-fed-version master \
  --oai-nwdaf-version http2_server_support \
  --open5gs-version 2.7.2 \
  --packetrusher-version 80a7f4bc63d9563a8ec58ba126440d94018a35a2 \
  --sockperf-version 19accb5229503dac7833f03713b978cb7fc48762 \
  --srsran5g-version 24_10_1 \
  --ueransim-version 2fc85e3e422b9a981d330bf6ff945136bfae97f3 \
  --virt-dpdk-version v24.11
```

Also, 5gdeploy has supported only Ubuntu 24.04, but it has been tested to support Ubuntu 20.04, 22.04, 24.04, as well as Linux distributions based on these Ubuntu versions (docker/build.sh no longer relies on `lsb_release -c -s`).

Documentation has been updated accordingly.