### PR TITLE
compose: use official mariadb image

### DIFF
--- a/compose/database.ts
+++ b/compose/database.ts
@@ -10,15 +10,15 @@ export const mysql = {
    * @param startdb - Host directory containing SQL scripts.
    */
   define(ctx: ComposeContext, startdb?: string): ComposeService {
-    const s = ctx.defineService("sql", "bitnami/mariadb:10.6", ["db"]);
-    s.environment.ALLOW_EMPTY_PASSWORD = "yes";
-    s.environment.MARIADB_EXTRA_FLAGS = "--max_connections=1000";
+    const s = ctx.defineService("sql", "mariadb:10.6", ["db"]);
+    s.environment.MARIADB_ALLOW_EMPTY_ROOT_PASSWORD = "yes";
+    s.command = ["mysqld", "--max_connections=1000", "--character-set-server=utf8", "--collation-server=utf8_general_ci"];
 
     if (startdb) {
       s.volumes.push({
         type: "bind",
         source: startdb,
-        target: "/docker-entrypoint-startdb.d",
+        target: "/docker-entrypoint-initdb.d",
         read_only: true,
       });
     }


### PR DESCRIPTION
Fix startup failure where `bitnami/mariadb:10.6` can't be pulled (error below) by switching SQL service to the official `mariadb:10.6` image, updating initdb mount/env accordingly.

```console
[5gdeploy] Starting the scenario on PRIMARY
[+] Running 9/13
 ✘ smf Error             manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ✘ udm Error             manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ✘ ausf Error            manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ⠋ upf141 Pulling                                                                                                                                                                1.0s 
 ✘ nrf Error             manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ✘ upf140 Error          manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ⠏ grafana Pulling                                                                                                                                                               1.0s 
 ⠏ upf1 Pulling                                                                                                                                                                  1.0s 
 ✘ amf Error             manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ⠏ udr Pulling                                                                                                                                                                   1.0s 
 ✘ sql Error             manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ✘ processexporter Error manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
 ✘ prometheus Error      manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown                                                                         1.0s 
Error response from daemon: manifest for bitnami/mariadb:10.6 not found: manifest unknown: manifest unknown
```