### PR TITLE
compose: use official mongodb image

### DIFF
--- a/compose/database.ts
+++ b/compose/database.ts
@@ -89,13 +89,12 @@ export const mongo = {
     mongoUrl,
     initdb,
   }: mongo.Options = {}): ComposeService {
-    const s = ctx.defineService(ct, "bitnami/mongodb:7.0-debian-12", [net]);
-    s.environment.ALLOW_EMPTY_PASSWORD = "yes";
+    const s = ctx.defineService(ct, "mongo:7.0", [net]);
 
     if (mongoUrl) {
       assert(mongoUrl.protocol === "mongodb:");
       if (mongoUrl.pathname.length > 1) {
-        s.environment.MONGODB_DATABASE = mongoUrl.pathname.slice(1); // strip leading "/"
+        s.environment.MONGO_INITDB_DATABASE = mongoUrl.pathname.slice(1); // strip leading "/"
       }
       mongoUrl.hostname = getIP(s, net);
       mongoUrl.port = "27017";


### PR DESCRIPTION
There is one last bitnami reference in the repo that I missed yesterday, preventing Open5GS from starting. The official one uses no authentication by default so that line was omitted.

```console
[5gdeploy] Starting the scenario on PRIMARY
[+] up 5/5
 ! Image prom/prometheus               Interrupted                                                                           0.5s
 ! Image grafana/grafana-oss           Interrupted                                                                           0.5s
 ! Image gradiant/open5gs-webui:2.7.6  Interrupted                                                                           0.5s
 ! Image ncabatoff/process-exporter    Interrupted                                                                           0.5s
 ✘ Image bitnami/mongodb:7.0-debian-12 Error manifest for bitnami/mongodb:7.0-debian-12 not found: manifest unknown...       0.5s
Error response from daemon: manifest for bitnami/mongodb:7.0-debian-12 not found: manifest unknown: manifest unknown
```